### PR TITLE
Fixing gameobject pulling only last bug

### DIFF
--- a/GameObjectPooling/Scripts/Helpers/Pooling/Pool.cs
+++ b/GameObjectPooling/Scripts/Helpers/Pooling/Pool.cs
@@ -64,7 +64,7 @@ public abstract class Pool<T, C> where T : PoolableMonoBehaviour<C> where C : Po
 
     public T PullGameObjectFromPool(C config) {
         for (int i = 0; i < pool.Count; i++) {
-            if (!pool[i].gameObject.activeInHierarchy) {
+            if (!pool[i].gameObject.activeSelf) {
                 pool[i].gameObject.SetActive(true);
                 pool[i].Prepare(config);
                 return pool[i];


### PR DESCRIPTION
This allows to pull objects even when some component of the parent was not active. Tested and works.